### PR TITLE
FEAT: Adicionando in e not_in

### DIFF
--- a/src/main/kotlin/com/orchestrator/payments/application/adapter/ProcessBtreeAdapter.kt
+++ b/src/main/kotlin/com/orchestrator/payments/application/adapter/ProcessBtreeAdapter.kt
@@ -83,13 +83,18 @@ class ProcessBtreeAdapter: ProcessBtreePort {
             OperatorEnum.LESS_THAN -> actual < expected
             OperatorEnum.GREATER_THAN_OR_EQUAL_TO -> actual >= expected
             OperatorEnum.LESS_THAN_OR_EQUAL_TO -> actual <= expected
+            OperatorEnum.NOT_IN -> false
+            OperatorEnum.IN -> false
         }
     }
 
     private fun validateStringCondition(actualValue: String, operator: OperatorEnum, expectedValue: String): Boolean {
+        val teste = 0
         return when (operator) {
             OperatorEnum.EQUALS -> actualValue == expectedValue
             OperatorEnum.NOT_EQUALS -> actualValue != expectedValue
+            OperatorEnum.NOT_IN -> !expectedValue.replace(" ", "").split(",").contains(actualValue)
+            OperatorEnum.IN -> expectedValue.replace(" ", "").split(",").contains(actualValue)
             else -> false
         }
     }

--- a/src/main/kotlin/com/orchestrator/payments/application/adapter/ProcessRulesAdapter.kt
+++ b/src/main/kotlin/com/orchestrator/payments/application/adapter/ProcessRulesAdapter.kt
@@ -54,6 +54,8 @@ class ProcessRulesAdapter: ProcessRulesPort {
             OperatorEnum.LESS_THAN -> actual < expected
             OperatorEnum.GREATER_THAN_OR_EQUAL_TO -> actual >= expected
             OperatorEnum.LESS_THAN_OR_EQUAL_TO -> actual <= expected
+            OperatorEnum.NOT_IN -> false
+            OperatorEnum.IN -> false
         }
     }
 
@@ -61,6 +63,8 @@ class ProcessRulesAdapter: ProcessRulesPort {
         return when (operator) {
             OperatorEnum.EQUALS -> actualValue == expectedValue
             OperatorEnum.NOT_EQUALS -> actualValue != expectedValue
+            OperatorEnum.NOT_IN -> !expectedValue.replace(" ", "").split(",").contains(actualValue)
+            OperatorEnum.IN -> expectedValue.replace(" ", "").split(",").contains(actualValue)
             else -> false
         }
     }

--- a/src/main/kotlin/com/orchestrator/payments/domain/OperatorEnum.kt
+++ b/src/main/kotlin/com/orchestrator/payments/domain/OperatorEnum.kt
@@ -3,6 +3,8 @@ package com.orchestrator.payments.domain
 enum class OperatorEnum(val description: String) {
     EQUALS("Igual a"),
     NOT_EQUALS("Diferente de"),
+    NOT_IN("Não está entre"),
+    IN("Está entre"),
     GREATER_THAN("Maior que"),
     LESS_THAN("Menor que"),
     GREATER_THAN_OR_EQUAL_TO("Maior ou igual a"),


### PR DESCRIPTION
## Resumo por Sourcery

Adiciona os operadores de comparação IN e NOT_IN ao domínio e aos adaptadores, permitindo verificações de inclusão baseadas em string enquanto simula casos numéricos como falso.

Novas Funcionalidades:
- Introduz os operadores IN e NOT_IN em OperatorEnum
- Implementa a lógica IN e NOT_IN baseada em string em ProcessBtreeAdapter e ProcessRulesAdapter

Melhorias:
- Avaliações numéricas padrão de IN e NOT_IN como falso em ambos os adaptadores

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Add IN and NOT_IN comparison operators to the domain and adapters, enabling string-based inclusion checks while stubbing numeric cases to false.

New Features:
- Introduce IN and NOT_IN operators in OperatorEnum
- Implement string-based IN and NOT_IN logic in ProcessBtreeAdapter and ProcessRulesAdapter

Enhancements:
- Default numeric IN and NOT_IN evaluations to false in both adapters

</details>